### PR TITLE
WYSIWYG bg color

### DIFF
--- a/dark-theme.css
+++ b/dark-theme.css
@@ -14,6 +14,7 @@ hr{background-color:rgba(0,0,0,.2)}
 .editor-toolbar{background-color:#282a36;border-bottom:1px solid rgba(0,0,0,.2);}
 .title-input.page-title .input{background-color:#282a36;}
 #markdown-editor .markdown-editor-wrap {background-color: #282a36;}
+#tinymce {background-color: #282a36;}
 
 /* text stuff */
 body{color: #f8f8f2;}


### PR DESCRIPTION
WYSIWYG bg color

Here's what I have so far with respect to #4 

It looks like hot garbage since tinymce lives inside an iframe and the style isn't being applied to the entirety of the white area(?) but I'm able to see what I'm typing so there's something.

![image](https://user-images.githubusercontent.com/3334013/37238561-c7050b56-23dd-11e8-9413-fc0763a6d996.png)

edit: I am using Firefox FWIW
