### PR TITLE
Updated hover for cards

### DIFF
--- a/dark-theme.css
+++ b/dark-theme.css
@@ -34,7 +34,10 @@ h2, h3, h4, h5, h6 {font-weight: 700}
 .entity-list .page.draft .text-page {color: #bd93f9;}
 .card .entity-list-item:not(.no-hover):hover {background-color: #787878 !important;}
 .card .entity-list-item:not(.no-hover):hover .text-muted {color: white !important;}
-
+.setting-list-label {color: #999;}
+.tag-item .tag-value {background-color: rgba(255, 255, 255, 0.1);}
+.tag-item a {color: #f8f8f2;}
+.text-small {color: #777 !important;}
 
 /* border changes */
 header {border-bottom: 0;}

--- a/dark-theme.css
+++ b/dark-theme.css
@@ -32,6 +32,9 @@ h1 {font-weight: 900}
 h2, h3, h4, h5, h6 {font-weight: 700}
 .faded a, .faded button, .faded span, .faded span>div {color: #f8f8f2;}
 .entity-list .page.draft .text-page {color: #bd93f9;}
+.card .entity-list-item:not(.no-hover):hover {background-color: #787878 !important;}
+.card .entity-list-item:not(.no-hover):hover .text-muted {color: white !important;}
+
 
 /* border changes */
 header {border-bottom: 0;}

--- a/dark-theme.css
+++ b/dark-theme.css
@@ -18,6 +18,7 @@ hr{background-color:rgba(0,0,0,.2)}
 .title-input.page-title .input{background-color:#282a36;}
 #markdown-editor .markdown-editor-wrap {background-color: #282a36;}
 .card{  background-color: #282a36;box-shadow:none}
+.comment-box {background-color: #333644;}
 
 /* text stuff */
 body{color: #f8f8f2;}


### PR DESCRIPTION
Changes the hover colour for cards (e.g. books/chapters/pages) to a darker colour. Also change the text colour of the text-muted class when a card has been hovered to make it readable

Moved from this:

![Screenshot from 2019-09-17 21-54-37](https://user-images.githubusercontent.com/36062479/65078950-aeee9c00-d98d-11e9-859a-58478d357bfd.png)

to this: 

![Screenshot from 2019-09-17 21-54-53](https://user-images.githubusercontent.com/36062479/65078955-b01fc900-d98d-11e9-8a1a-957bf487e9c4.png)
